### PR TITLE
Add field criticality

### DIFF
--- a/src/Opossum/Opossum.hs
+++ b/src/Opossum/Opossum.hs
@@ -303,12 +303,13 @@ data ExternalAttribution =
     , _licenseName           :: Maybe T.Text
     , _licenseText           :: Maybe T.Text
     , _url                   :: Maybe T.Text
+    , _criticality           :: Maybe T.Text
     , _flags                 :: ExternalAttribution_Flags
     }
   deriving (Show, Generic, Eq)
 
 instance A.ToJSON ExternalAttribution where
-  toJSON (ExternalAttribution source attributionConfidence comment originId coordinates copyright licenseName licenseText url flags) =
+  toJSON (ExternalAttribution source attributionConfidence comment originId coordinates copyright licenseName licenseText url criticality flags) =
     objectNoNulls
       ([ "source" A..= source
        , "attributionConfidence" A..= attributionConfidence
@@ -318,6 +319,7 @@ instance A.ToJSON ExternalAttribution where
        , "licenseText" A..= licenseText
        , "originId" A..= originId
        , "url" A..= url
+       , "criticality" A..= criticality
        ] ++
        (opoossumCoordinatesPreObjectList coordinates) ++
        (opoossumExternalAttributionFlagsPreObjectList flags))
@@ -356,6 +358,12 @@ instance A.FromJSON ExternalAttribution where
              Just "" -> Nothing
              l       -> l)
           (v A..:? "url")
+      criticality <-
+        fmap
+          (\case
+             Just "" -> Nothing
+             l       -> l)
+          (v A..:? "criticality")
       flags <- A.parseJSON (A.Object v) :: A.Parser ExternalAttribution_Flags
       return
         (ExternalAttribution
@@ -368,6 +376,7 @@ instance A.FromJSON ExternalAttribution where
            licenseName
            licenseText
            url
+           criticality
            flags)
 
 eaIsSignificant :: ExternalAttribution -> Bool

--- a/src/Opossum/OpossumDependencyCheckUtils.hs
+++ b/src/Opossum/OpossumDependencyCheckUtils.hs
@@ -495,6 +495,7 @@ dependencyCheckDependencyToOpossum (dcd@DependencyCheckDependency { _dcd_isVirtu
                 , _licenseName = Nothing
                 , _licenseText = Nothing
                 , _url = url
+                , _criticality = Nothing
                 , _flags = mempty {_isFollowUp = vulnerabilities /= []}
                 }
             opossum =

--- a/src/Opossum/OpossumExiftoolUtils.hs
+++ b/src/Opossum/OpossumExiftoolUtils.hs
@@ -105,6 +105,7 @@ exiftoolEntryToEA o =
                Nothing
                Nothing
                Nothing
+               Nothing
                mempty
         else Nothing
 

--- a/src/Opossum/OpossumSPDXUtils.hs
+++ b/src/Opossum/OpossumSPDXUtils.hs
@@ -69,6 +69,7 @@ spdxFileToEA (SPDXFile { _SPDXFile_SPDXID = spdxid
         fmap (T.pack . renderSpdxLicense) (spdxMaybeToMaybe license)
     , _licenseText = Nothing -- TODO
     , _url = Nothing
+    , _criticality = Nothing
     , _flags = mempty
     }
 
@@ -117,6 +118,7 @@ spdxPackageToEA (SPDXPackage { _SPDXPackage_SPDXID = spdxid
         fmap (T.pack . renderSpdxLicense) (spdxMaybeToMaybe license)
     , _licenseText = Nothing -- TODO
     , _url = Nothing
+    , _criticality = Nothing
     , _flags = justPreselectedFlags
     }
 

--- a/src/Opossum/OpossumScancodeUtils.hs
+++ b/src/Opossum/OpossumScancodeUtils.hs
@@ -267,6 +267,7 @@ scancodePackageToEA scp@(ScancodePackage { _scp_purl = purl
         (renderLicense licenses)
         Nothing
         Nothing
+        Nothing
         justPreselectedFlags
 
 opossumFromScancodePackage :: ScancodePackage -> Maybe FilePath -> IO Opossum
@@ -325,6 +326,7 @@ scancodeFileEntryToEA (scfe@ScancodeFileEntry { _scfe_license = licenses
                (Coordinates Nothing Nothing Nothing Nothing Nothing)
                ((Just . T.pack . unlines) copyrights)
                (renderLicense licenses)
+               Nothing
                Nothing
                Nothing
                mempty
@@ -487,6 +489,7 @@ scanpipeLayerToEA (ScanpipeLayer {_spl_created_by = cmd}) =
         (Just (T.pack cmd))
         Nothing
         (Coordinates Nothing Nothing Nothing Nothing Nothing)
+        Nothing
         Nothing
         Nothing
         Nothing

--- a/src/Opossum/OpossumScanossUtils.hs
+++ b/src/Opossum/OpossumScanossUtils.hs
@@ -285,6 +285,7 @@ scanossFindingsToOpossum (fn, ScanossFindings fs) =
                 licenses
                 Nothing
                 (_ScanossFinding_url f)
+                Nothing
                 mempty
         let eas = mkExternalAttributionSources source Nothing 5
         -- TODO: dependencies

--- a/src/Opossum/OpossumUtils.hs
+++ b/src/Opossum/OpossumUtils.hs
@@ -75,7 +75,7 @@ cleanupLicense (Just t ) = case T.stripPrefix ", " t of
 
 mergifyEA
   :: ExternalAttribution -> ExternalAttribution -> Maybe ExternalAttribution
-mergifyEA left@(ExternalAttribution { _source = ExternalAttribution_Source source _, _attributionConfidence = attributionConfidence, _comment = comment, _originId = originId, _coordinates = coordinates, _copyright = copyright, _licenseName = licenseName, _licenseText = licenseText, _flags = flags }) (right@ExternalAttribution { _source = ExternalAttribution_Source source' _, _attributionConfidence = attributionConfidence', _comment = comment', _originId = originId', _coordinates = coordinates', _copyright = copyright', _licenseName = licenseName', _licenseText = licenseText', _flags = flags' })
+mergifyEA left@(ExternalAttribution { _source = ExternalAttribution_Source source _, _attributionConfidence = attributionConfidence, _comment = comment, _originId = originId, _coordinates = coordinates, _copyright = copyright, _licenseName = licenseName, _licenseText = licenseText, _criticality = criticality, _flags = flags }) (right@ExternalAttribution { _source = ExternalAttribution_Source source' _, _attributionConfidence = attributionConfidence', _comment = comment', _originId = originId', _coordinates = coordinates', _copyright = copyright', _licenseName = licenseName', _licenseText = licenseText', _criticality = criticality', _flags = flags' })
   = if left
        == right
        || (and

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -196,6 +196,7 @@ opossumSpec = do
                      (Just "MIT AND GPL-2.0-or-later")
                      Nothing
                      (Just "https://github.com/some/repo")
+                     Nothing
                      mempty
              ea <-
                case (A.eitherDecode ea_str :: Either String ExternalAttribution) of
@@ -238,6 +239,7 @@ opossumSpec = do
                      Nothing
                      Nothing
                      Nothing
+                     Nothing
                      justPreselectedFlags
              ea <-
                case (A.eitherDecode ea_str :: Either String ExternalAttribution) of
@@ -269,6 +271,7 @@ opossumSpec = do
             Nothing
             Nothing
             Nothing
+            Nothing
             mempty
         ea2 =
           ExternalAttribution
@@ -281,6 +284,7 @@ opossumSpec = do
             Nothing
             Nothing
             Nothing
+            Nothing
             mempty
         ea3 =
           ExternalAttribution
@@ -289,6 +293,7 @@ opossumSpec = do
             Nothing
             Nothing
             (expected_coordinates "1.2")
+            Nothing
             Nothing
             Nothing
             Nothing


### PR DESCRIPTION
In order to be able to merge input documents for OpossumUI without loosing information on criticality of signals, the field is added to ExternalAttribution.



